### PR TITLE
<config/docker>: use cloud sql in place of container-based postgres

### DIFF
--- a/data_team/metabase_server/.env.example
+++ b/data_team/metabase_server/.env.example
@@ -1,2 +1,3 @@
 POSTGRES_USER=
 POSTGRES_PASSWORD=
+CLOUD_SQL_IP=<get the public IP from GCP Cloud SQL's db instance>

--- a/data_team/metabase_server/README.md
+++ b/data_team/metabase_server/README.md
@@ -3,7 +3,7 @@
 [Metabase](https://www.metabase.com/) is an open-source business intelligence tool adopted by PyCon TW Data Team to track cross-year conference data. The docker-compose script handles four services:
 
 - `metabase`: The Metabase server.
-- `postgres`: The database storing the data used by the Metabase server.
+    - `postgres`: The database storing the data used by the Metabase server. Please get the public IP of our GCP cloud SQL and place it into [docker-compose.yml](./docker-compose.yml) 's `MB_DB_HOST`
 - `nginx`: The Nginx proxy that forces HTTPS connection and passes the requests to the metabase service. See the [configuration](./nginx) for details.
 - `certbot`: The service is responsible for the TSL certification auto-renewal of `metabase.pycon.tw`.
 

--- a/data_team/metabase_server/README.md
+++ b/data_team/metabase_server/README.md
@@ -1,6 +1,6 @@
 # Metabase Server
 
-[Metabase](https://www.metabase.com/) is an open-source business intelligence tool adopted by PyCon TW Data Team to track cross-year conference data. The docker-compose script handles four services:
+[Metabase](https://www.metabase.com/) is an open-source business intelligence tool adopted by PyCon TW Data Team to track cross-year conference data. The docker-compose script handles several services, as listed below:
 
 - `metabase`: The Metabase server.
     - `postgres`: The database storing the data used by the Metabase server. Please get the public IP of our GCP cloud SQL and place it into [docker-compose.yml](./docker-compose.yml) 's `MB_DB_HOST`

--- a/data_team/metabase_server/docker-compose.yml
+++ b/data_team/metabase_server/docker-compose.yml
@@ -26,17 +26,6 @@ services:
       - ./data/certbot/www:/var/www/certbot
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
 
-  postgres:
-    image: postgres
-    restart: always
-    volumes:
-      - ./data/pgdata:/var/lib/postgresql/data/pgdata
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=metabase
-      - PGDATA="/var/lib/postgresql/data/pgdata"
-
   metabase:
     restart: always
     image: metabase/metabase
@@ -48,7 +37,7 @@ services:
       - MB_REDIRECT_ALL_REQUESTS_TO_HTTPS=false
       - MB_SITE_URL=null
       - MB_DB_DBNAME=metabase
-      - MB_DB_HOST=postgres
+      - MB_DB_HOST=<get the public IP from GCP Cloud SQL's db instance>
       - MB_DB_PASS=${POSTGRES_PASSWORD}
       - MB_DB_PORT=5432
       - MB_DB_TYPE=postgres

--- a/data_team/metabase_server/docker-compose.yml
+++ b/data_team/metabase_server/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - MB_REDIRECT_ALL_REQUESTS_TO_HTTPS=false
       - MB_SITE_URL=null
       - MB_DB_DBNAME=metabase
-      - MB_DB_HOST=<get the public IP from GCP Cloud SQL's db instance>
+      - MB_DB_HOST=${CLOUD_SQL_IP}
       - MB_DB_PASS=${POSTGRES_PASSWORD}
       - MB_DB_PORT=5432
       - MB_DB_TYPE=postgres


### PR DESCRIPTION
check the detail of our cloud sql instance here: https://console.cloud.google.com/sql/instances/dev-team-db-for-web-data-infra/overview?authuser=0&cloudshell=true&hl=zh-tw&project=pycontw-225217&supportedpurview=project